### PR TITLE
增加支持从视频文件提取音频并完成转码最后生成srt的命令行工具

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@ mutagen
 gradio_client #用于处理PDF文档
 langdetect #验证检测语言
 python-docx #处理Word文档
+av #用于视频音频提取和处理（命令行工具需要）
 # 构建工具（仅开发需要）
 pyinstaller 

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,246 @@
+# 命令行工具 - 自动字幕生成
+
+独立的命令行工具，用于从视频文件自动生成字幕。支持长视频自动分割、批量转录和 LLM 优化。
+
+## 功能特性
+
+- ✅ **视频音频提取**: 支持多种视频格式（mp4, mkv, avi, webm 等）
+- ✅ **智能音频分割**: 自动将超长音频分割为 28 分钟片段（避开 ElevenLabs 30 分钟限制）
+- ✅ **静音检测分割**: 在静音处切割，避免截断句子
+- ✅ **批量转录**: 支持 ElevenLabs API（付费）和 Web 版（免费，可能失效）
+- ✅ **JSON 合并**: 自动合并多个转录结果并调整时间戳
+- ✅ **LLM 优化**: 使用大语言模型优化字幕分割和断句
+- ✅ **配置共享**: 与 GUI 版本共享配置文件
+
+## 安装依赖
+
+```bash
+# 安装所有依赖
+pip install -r requirements.txt
+
+# 或单独安装命令行工具所需的依赖
+pip install av requests mutagen langdetect
+```
+
+**重要**: `av` 库是 FFmpeg 的 Python 绑定，用于视频音频处理。如果安装失败，请确保系统已安装 FFmpeg。
+
+## 使用方法
+
+### 基本使用
+
+```bash
+# 最简单的使用方式（需要先在 GUI 中配置 API Key）
+python tools/auto_subtitle.py video.mp4
+```
+
+### 指定语言
+
+```bash
+# 指定目标语言（支持: zh, ja, en, ko）
+python tools/auto_subtitle.py video.mp4 --language ja
+```
+
+### 使用 API Key
+
+```bash
+# 使用 ElevenLabs API Key（推荐，免费版已失效）
+python tools/auto_subtitle.py video.mp4 --elevenlabs-api-key YOUR_ELEVENLABS_KEY
+
+# 使用 LLM API Key
+python tools/auto_subtitle.py video.mp4 --llm-api-key sk-xxx
+
+# 同时指定两个 API Key
+python tools/auto_subtitle.py video.mp4 \
+  --llm-api-key sk-xxx \
+  --elevenlabs-api-key el-xxx
+```
+
+### 完整配置示例
+
+```bash
+python tools/auto_subtitle.py video.mp4 \
+  --llm-api-key sk-xxx \
+  --elevenlabs-api-key el-xxx \
+  --language ja \
+  --api-url https://api.deepseek.com/v1/chat/completions \
+  --model deepseek-chat \
+  --temperature 0.3 \
+  --max-duration 1680
+```
+
+## 参数说明
+
+### 必需参数
+
+- `video`: 视频文件路径（支持 mp4, mkv, avi, webm, mov 等格式）
+
+### 可选参数
+
+- `--llm-api-key`: LLM API Key（用于字幕优化，不指定则使用配置文件中的）
+- `--elevenlabs-api-key`: ElevenLabs API Key（用于音频转录，不指定则使用免费版）
+- `--language`: 目标语言，可选值: `zh`(中文), `ja`(日文), `en`(英文), `ko`(韩文)
+- `--api-url`: LLM API 地址（默认: DeepSeek API）
+- `--model`: LLM 模型名称（默认: deepseek-chat）
+- `--temperature`: LLM 温度参数（默认: 0.3，范围 0.0-1.0）
+- `--max-duration`: 音频分割最大时长，单位秒（默认: 1680 = 28分钟）
+
+## 工作流程
+
+1. **音频提取**: 从视频中提取音频并转换为 OGG 格式（16kHz, 单声道）
+2. **音频分割**: 如果音频超过 28 分钟，自动分割为多个片段（在静音处切割）
+3. **批量转录**: 使用 ElevenLabs API 转录所有音频片段
+4. **JSON 合并**: 合并多个转录结果，调整时间戳
+5. **LLM 优化**: 使用大语言模型优化字幕分割和断句
+6. **SRT 生成**: 生成标准 SRT 字幕文件
+
+## 配置文件
+
+工具会自动读取 GUI 保存的配置文件：`~/.heal_jimaku/config/config.json`
+
+如果配置文件中已保存 API Key，可以直接使用：
+
+```bash
+# 无需指定 API Key，自动从配置文件读取
+python tools/auto_subtitle.py video.mp4
+```
+
+## 支持的文件格式
+
+### 视频格式
+- MP4, MKV, AVI, WebM, MOV, FLV, WMV, M4V, TS, MTS
+
+### 音频格式
+- MP3, WAV, FLAC, M4A, OGG, Opus, AAC, WMA
+
+## 输出文件
+
+- **SRT 字幕**: 与视频文件同名，扩展名为 `.srt`
+- **临时文件**: 音频提取和分割产生的临时文件保存在系统临时目录
+
+## 常见问题
+
+### 1. PyAV 安装失败
+
+```bash
+# Windows: 下载预编译的 wheel 文件
+pip install av
+
+# Linux: 先安装 FFmpeg 开发库
+sudo apt-get install libavformat-dev libavcodec-dev libavdevice-dev libavutil-dev libswscale-dev libswresample-dev libavfilter-dev
+pip install av
+
+# macOS: 使用 Homebrew 安装 FFmpeg
+brew install ffmpeg
+pip install av
+```
+
+### 2. ElevenLabs 免费版失效
+
+ElevenLabs 免费版已经失效，建议使用 API Key：
+
+```bash
+python tools/auto_subtitle.py video.mp4 --elevenlabs-api-key YOUR_KEY
+```
+
+### 3. LLM API Key 从哪里获取？
+
+- **DeepSeek**: https://platform.deepseek.com/
+- **OpenAI**: https://platform.openai.com/
+- **其他兼容 OpenAI API 的服务**
+
+### 4. 如何处理超长视频？
+
+工具会自动将超过 28 分钟的音频分割为多个片段，无需手动处理。分割点会选择在静音处，避免截断句子。
+
+### 5. 生成的字幕在哪里？
+
+字幕文件与视频文件在同一目录，文件名相同，扩展名为 `.srt`。
+
+例如：
+- 视频: `video.mp4`
+- 字幕: `video.srt`
+
+## 技术架构
+
+```
+tools/
+├── auto_subtitle.py          # 命令行入口
+└── core/
+    ├── audio_extractor.py    # 音频提取和分割
+    ├── audio_processor.py    # 音频处理编排
+    └── subtitle_pipeline.py  # 字幕生成流程
+
+复用 src/ 目录的模块:
+├── core/
+│   ├── elevenlabs_api.py     # ElevenLabs API 客户端
+│   ├── transcription_parser.py # 转录数据解析
+│   ├── srt_processor.py      # SRT 字幕处理
+│   ├── llm_api.py            # LLM API 客户端
+│   └── data_models.py        # 数据模型
+└── config.py                 # 配置管理
+```
+
+## 示例输出
+
+```
+使用配置:
+  LLM API URL: https://api.deepseek.com/v1/chat/completions
+  LLM 模型: deepseek-chat
+  LLM 温度: 0.3
+  ElevenLabs API Key: el-1234567...abcd
+  语言: ja
+
+[00:12:34] 开始处理视频: video.mp4
+============================================================
+[00:12:34] 步骤 1/5: 提取音频
+  提取音频中...  提取进度: 100.0%
+[00:12:45] ✓ 音频提取完成: /tmp/video_extracted.ogg
+============================================================
+[00:12:45] 步骤 2/5: 检查音频时长并分割
+  音频时长: 3600.0秒 (60.0分钟)
+  最大时长限制: 1680秒 (28.0分钟)
+  音频超过限制，开始分割...
+[00:13:15] ✓ 音频已分割为 3 个片段
+============================================================
+[00:13:15] 步骤 3/5: ElevenLabs 转录
+  [1/3] 转录: video_part001.ogg (1680.0秒)
+  使用 ElevenLabs API (付费版)
+  ✓ 已保存: /tmp/video_part001.json
+  [2/3] 转录: video_part002.ogg (1680.0秒)
+  ...
+[00:25:30] ✓ 转录完成，生成 3 个JSON文件
+============================================================
+[00:25:30] 步骤 4/5: 合并转录结果
+  合并 3 个JSON文件...
+  ✓ 成功合并 3 个文件，共 5432 个单词
+[00:25:31] ✓ JSON合并完成: /tmp/video_merged.json
+============================================================
+[00:25:31] 步骤 5/5: LLM优化并生成SRT
+  解析转录JSON...
+  ✓ 解析完成: 5432 个单词
+  文本长度: 12345 字符
+  调用LLM进行文本分割优化...
+  ✓ LLM分割完成: 234 个片段
+  生成SRT字幕...
+  ✓ 生成 234 条字幕
+[00:25:45] ✓ SRT生成完成: video.srt
+============================================================
+[00:25:45] ✓ 全部完成！
+
+============================================================
+✓ 字幕已生成: video.srt
+============================================================
+```
+
+## 许可证
+
+本工具是 heal-jimaku 项目的一部分，遵循项目的开源许可证。
+
+## 贡献
+
+欢迎提交 Issue 和 Pull Request！
+
+---
+
+**作者**: fuxiaomoke  
+**版本**: 0.2.2.0

--- a/tools/README.md
+++ b/tools/README.md
@@ -43,7 +43,7 @@ python tools/auto_subtitle.py video.mp4 --language ja
 ### 使用 API Key
 
 ```bash
-# 使用 ElevenLabs API Key（推荐，免费版已失效）
+# 使用 ElevenLabs API Key（推荐，免费版的限制不清晰，有时报错）
 python tools/auto_subtitle.py video.mp4 --elevenlabs-api-key YOUR_ELEVENLABS_KEY
 
 # 使用 LLM API Key
@@ -136,7 +136,7 @@ pip install av
 
 ### 2. ElevenLabs 免费版失效
 
-ElevenLabs 免费版已经失效，建议使用 API Key：
+ElevenLabs 免费版有时候直接报错（封IP？），建议使用 API Key：
 
 ```bash
 python tools/auto_subtitle.py video.mp4 --elevenlabs-api-key YOUR_KEY
@@ -235,12 +235,3 @@ tools/
 ## 许可证
 
 本工具是 heal-jimaku 项目的一部分，遵循项目的开源许可证。
-
-## 贡献
-
-欢迎提交 Issue 和 Pull Request！
-
----
-
-**作者**: fuxiaomoke  
-**版本**: 0.2.2.0

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,7 @@
+"""
+Tools package for heal-jimaku
+
+Command-line tools for video subtitle generation.
+"""
+
+__version__ = "0.2.2.0"

--- a/tools/auto_subtitle.py
+++ b/tools/auto_subtitle.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""
+自动字幕生成工具 - 命令行版本
+
+独立的命令行工具，实现视频自动生成字幕的完整流程：
+1. 视频音频提取 → OGG 编码 → 28分钟分割
+2. ElevenLabs Web 批量转录 → JSON 合并
+3. LLM 优化 → SRT 生成
+
+使用示例:
+    python tools/auto_subtitle.py video.mp4
+    python tools/auto_subtitle.py video.mp4 --language ja
+    python tools/auto_subtitle.py video.mp4 --llm-api-key sk-xxx
+
+作者: fuxiaomoke
+版本: 0.2.2.0
+"""
+
+import sys
+import os
+import argparse
+import json
+
+# 添加项目根目录和 src 目录到 Python 路径
+project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+src_path = os.path.join(project_root, 'src')
+if src_path not in sys.path:
+    sys.path.insert(0, src_path)
+
+# 从 src 导入配置模块
+import config as app_config
+
+# 从 tools.core 导入字幕生成流程
+from tools.core.subtitle_pipeline import SubtitlePipeline
+
+
+def load_config():
+    """加载配置文件（复用 GUI 的配置）"""
+    if not os.path.exists(app_config.CONFIG_FILE):
+        return {}
+    
+    try:
+        with open(app_config.CONFIG_FILE, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    except Exception as e:
+        print(f"警告: 加载配置文件失败: {e}")
+        return {}
+
+
+def save_config(config_data):
+    """保存配置文件"""
+    try:
+        if not os.path.exists(app_config.CONFIG_DIR):
+            os.makedirs(app_config.CONFIG_DIR, exist_ok=True)
+        
+        with open(app_config.CONFIG_FILE, 'w', encoding='utf-8') as f:
+            json.dump(config_data, f, ensure_ascii=False, indent=2)
+    except Exception as e:
+        print(f"警告: 保存配置文件失败: {e}")
+
+
+def main():
+    """命令行入口"""
+    parser = argparse.ArgumentParser(
+        description='视频自动生成字幕工具（复用 GUI 配置）',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+使用示例:
+  # 基本使用（使用已保存的配置）
+  python tools/auto_subtitle.py video.mp4
+
+  # 指定语言
+  python tools/auto_subtitle.py video.mp4 --language ja
+
+  # 使用 ElevenLabs API Key（推荐）
+  python tools/auto_subtitle.py video.mp4 --elevenlabs-api-key YOUR_KEY
+
+  # 完整配置示例
+  python tools/auto_subtitle.py video.mp4 \\
+    --llm-api-key sk-xxx \\
+    --elevenlabs-api-key el-xxx \\
+    --language ja
+
+支持的语言: zh (中文), ja (日文), en (英文), ko (韩文)
+
+注意: 
+  - 工具会自动读取 GUI 保存的配置（~/.heal_jimaku/config/config.json）
+  - ElevenLabs 免费版已失效，建议使用 API Key
+        """
+    )
+    
+    # 必需参数
+    parser.add_argument(
+        'video',
+        help='视频文件路径（支持 mp4, mkv, avi, webm 等格式）'
+    )
+    
+    parser.add_argument(
+        '--llm-api-key',
+        help='LLM API Key（可选，不指定则使用配置文件中的）'
+    )
+    
+    parser.add_argument(
+        '--elevenlabs-api-key',
+        help='ElevenLabs API Key（用于音频转录，可选）'
+    )
+    
+    # 可选参数
+    parser.add_argument(
+        '--api-url',
+        default='https://api.deepseek.com/v1/chat/completions',
+        help='LLM API 地址（默认: DeepSeek）'
+    )
+    
+    parser.add_argument(
+        '--model',
+        default='deepseek-chat',
+        help='LLM 模型名称（默认: deepseek-chat）'
+    )
+    
+    parser.add_argument(
+        '--language',
+        choices=['zh', 'ja', 'en', 'ko'],
+        help='目标语言（可选，不指定则自动检测）'
+    )
+    
+    parser.add_argument(
+        '--max-duration',
+        type=int,
+        default=1680,
+        help='音频分割最大时长（秒，默认: 1680 = 28分钟）'
+    )
+    
+    parser.add_argument(
+        '--temperature',
+        type=float,
+        default=0.3,
+        help='LLM 温度参数（默认: 0.3）'
+    )
+    
+    args = parser.parse_args()
+    
+    # 验证输入文件
+    if not os.path.exists(args.video):
+        print(f"错误: 文件不存在: {args.video}")
+        sys.exit(1)
+    
+    # 加载配置文件
+    saved_config = load_config()
+    
+    # 获取当前 LLM 配置
+    current_profile = app_config.get_current_llm_profile(saved_config)
+    
+    # 构建配置（命令行参数优先，否则使用配置文件）
+    llm_api_key = args.llm_api_key or current_profile.get('api_key', '')
+    api_url = args.api_url if args.api_url != 'https://api.deepseek.com/v1/chat/completions' else current_profile.get('api_base_url', args.api_url)
+    model = args.model if args.model != 'deepseek-chat' else current_profile.get('model_name', args.model)
+    temperature = args.temperature if args.temperature != 0.3 else current_profile.get('temperature', args.temperature)
+    
+    # 获取 ElevenLabs API Key（命令行参数 > 配置文件）
+    elevenlabs_api_key = args.elevenlabs_api_key or saved_config.get(app_config.USER_ELEVENLABS_API_KEY_KEY, '')
+    
+    # 验证 LLM API Key
+    if not llm_api_key:
+        print("错误: 未找到 LLM API Key")
+        print("请使用以下方式之一提供 LLM API Key:")
+        print("  1. 在 GUI 中保存 API Key")
+        print("  2. 使用 --llm-api-key 参数")
+        sys.exit(1)
+    
+    config = {
+        'llm_api_key': llm_api_key,
+        'llm_api_url': api_url,
+        'llm_model': model,
+        'language': args.language,
+        'max_chunk_duration': args.max_duration,
+        'temperature': temperature,
+        'elevenlabs_api_key': elevenlabs_api_key  # 添加 ElevenLabs API Key
+    }
+    
+    # 显示使用的配置
+    print(f"使用配置:")
+    print(f"  LLM API URL: {api_url}")
+    print(f"  LLM 模型: {model}")
+    print(f"  LLM 温度: {temperature}")
+    if elevenlabs_api_key:
+        print(f"  ElevenLabs API Key: {elevenlabs_api_key[:10]}...{elevenlabs_api_key[-4:]}")
+    else:
+        print(f"  ElevenLabs: 使用免费版（可能失效）")
+    if args.language:
+        print(f"  语言: {args.language}")
+    print()
+    
+    # 执行流程
+    try:
+        pipeline = SubtitlePipeline(config)
+        srt_path = pipeline.process_video(args.video)
+        
+        print(f"\n" + "=" * 60)
+        print(f"OK: 字幕已生成: {srt_path}")
+        print("=" * 60)
+        
+        sys.exit(0)
+        
+    except KeyboardInterrupt:
+        print("\n\n用户中断操作")
+        sys.exit(130)
+        
+    except Exception as e:
+        print(f"\n\nError: 处理失败: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    # 处理 Windows 命令行编码问题
+    if sys.platform == 'win32':
+        import io
+        sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
+        sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding='utf-8')
+    main()

--- a/tools/core/__init__.py
+++ b/tools/core/__init__.py
@@ -1,0 +1,5 @@
+"""
+Core modules for command-line tools
+
+Audio extraction, processing, and subtitle pipeline.
+"""

--- a/tools/core/audio_extractor.py
+++ b/tools/core/audio_extractor.py
@@ -1,0 +1,637 @@
+"""
+音频提取模块 - 从视频文件中提取音频并转换为 OGG 格式
+
+使用 PyAV 库（FFmpeg Python 绑定）实现视频音频提取功能。
+支持长音频文件的智能分割（基于静音检测）和转录结果合并。
+
+作者: fuxiaomoke
+版本: 0.2.2.0
+"""
+
+import os
+import tempfile
+import json
+import math
+from pathlib import Path
+from typing import Optional, Tuple, List, Dict, Any
+
+# 支持的视频格式
+VIDEO_EXTENSIONS = {'.mkv', '.mp4', '.avi', '.webm', '.mov', '.flv', '.wmv', '.m4v', '.ts', '.mts'}
+
+# 支持的音频格式（无需转换）
+AUDIO_EXTENSIONS = {'.mp3', '.wav', '.flac', '.m4a', '.ogg', '.opus', '.aac', '.wma'}
+
+# OGG 编码参数（针对语音转录优化）
+OGG_SAMPLE_RATE = 16000  # 16kHz 足够语音识别
+OGG_CHANNELS = 1  # 单声道
+OGG_QUALITY = 4  # VBR 质量 0-10，4 约等于 128kbps，适合语音
+
+
+def is_video_file(file_path: str) -> bool:
+    """
+    检查文件是否为视频格式
+    
+    Args:
+        file_path: 文件路径
+        
+    Returns:
+        bool: 是否为视频文件
+    """
+    ext = Path(file_path).suffix.lower()
+    return ext in VIDEO_EXTENSIONS
+
+
+def is_audio_file(file_path: str) -> bool:
+    """
+    检查文件是否为音频格式
+    
+    Args:
+        file_path: 文件路径
+        
+    Returns:
+        bool: 是否为音频文件
+    """
+    ext = Path(file_path).suffix.lower()
+    return ext in AUDIO_EXTENSIONS
+
+
+def is_media_file(file_path: str) -> bool:
+    """
+    检查文件是否为支持的媒体格式（音频或视频）
+    
+    Args:
+        file_path: 文件路径
+        
+    Returns:
+        bool: 是否为媒体文件
+    """
+    return is_audio_file(file_path) or is_video_file(file_path)
+
+
+def extract_audio_to_ogg(
+    input_path: str,
+    output_path: Optional[str] = None,
+    sample_rate: int = OGG_SAMPLE_RATE,
+    channels: int = OGG_CHANNELS,
+    quality: int = OGG_QUALITY,
+    progress_callback: Optional[callable] = None
+) -> Tuple[bool, str, Optional[str]]:
+    """
+    从视频文件中提取音频并转换为 OGG 格式
+    
+    Args:
+        input_path: 输入视频文件路径
+        output_path: 输出 OGG 文件路径，如果为 None 则自动生成临时文件
+        sample_rate: 采样率，默认 16000 Hz
+        channels: 声道数，默认 1（单声道）
+        quality: VBR 质量等级 0-10，默认 4
+        progress_callback: 进度回调函数，接收 (current_seconds, total_seconds) 参数
+        
+    Returns:
+        Tuple[bool, str, Optional[str]]: (成功与否, 消息, 输出文件路径)
+    """
+    try:
+        import av
+    except ImportError:
+        return False, "PyAV 库未安装，请运行: pip install av", None
+    
+    if not os.path.exists(input_path):
+        return False, f"输入文件不存在: {input_path}", None
+    
+    # 生成输出路径
+    if output_path is None:
+        # 使用临时目录，文件名基于原文件名
+        base_name = Path(input_path).stem
+        temp_dir = tempfile.gettempdir()
+        output_path = os.path.join(temp_dir, f"{base_name}_extracted.ogg")
+    
+    try:
+        # 打开输入文件
+        input_container = av.open(input_path)
+        
+        # 查找音频流
+        audio_streams = [s for s in input_container.streams if s.type == 'audio']
+        if not audio_streams:
+            input_container.close()
+            return False, "视频文件中没有找到音频流", None
+        
+        # 使用第一个音频流
+        input_audio_stream = audio_streams[0]
+        
+        # 获取总时长用于进度显示
+        total_duration = float(input_container.duration) / av.time_base if input_container.duration else 0
+        
+        # 创建输出容器
+        output_container = av.open(output_path, 'w')
+        
+        # 添加 Vorbis 音频流 - 使用正确的 API
+        output_audio_stream = output_container.add_stream('libvorbis', rate=sample_rate)
+        output_audio_stream.codec_context.layout = 'mono' if channels == 1 else 'stereo'
+        
+        # 创建重采样器
+        resampler = av.AudioResampler(
+            format='fltp',  # libvorbis 需要 float planar 格式
+            layout='mono' if channels == 1 else 'stereo',
+            rate=sample_rate
+        )
+        
+        # 处理音频帧
+        frame_count = 0
+        for packet in input_container.demux(input_audio_stream):
+            for frame in packet.decode():
+                frame_count += 1
+                
+                # 进度回调
+                if progress_callback and total_duration > 0:
+                    current_time = float(frame.pts * input_audio_stream.time_base) if frame.pts else 0
+                    progress_callback(current_time, total_duration)
+                
+                # 重采样
+                resampled_frames = resampler.resample(frame)
+                
+                # 编码并写入
+                for resampled_frame in resampled_frames:
+                    for out_packet in output_audio_stream.encode(resampled_frame):
+                        output_container.mux(out_packet)
+        
+        # 刷新编码器
+        for out_packet in output_audio_stream.encode(None):
+            output_container.mux(out_packet)
+        
+        # 关闭容器
+        output_container.close()
+        input_container.close()
+        
+        # 检查输出文件
+        if os.path.exists(output_path) and os.path.getsize(output_path) > 0:
+            file_size_mb = os.path.getsize(output_path) / (1024 * 1024)
+            return True, f"音频提取成功，文件大小: {file_size_mb:.2f} MB", output_path
+        else:
+            return False, "音频提取失败：输出文件为空", None
+            
+    except Exception as e:
+        return False, f"音频提取失败: {str(e)}", None
+
+
+def get_media_info(file_path: str) -> Optional[dict]:
+    """
+    获取媒体文件信息
+    
+    Args:
+        file_path: 媒体文件路径
+        
+    Returns:
+        dict: 包含媒体信息的字典，失败返回 None
+    """
+    try:
+        import av
+    except ImportError:
+        return None
+    
+    try:
+        container = av.open(file_path)
+        
+        info = {
+            'duration': float(container.duration) / av.time_base if container.duration else 0,
+            'format': container.format.name,
+            'audio_streams': [],
+            'video_streams': []
+        }
+        
+        for stream in container.streams:
+            if stream.type == 'audio':
+                info['audio_streams'].append({
+                    'codec': stream.codec_context.name if stream.codec_context else 'unknown',
+                    'sample_rate': stream.sample_rate,
+                    'channels': stream.channels
+                })
+            elif stream.type == 'video':
+                info['video_streams'].append({
+                    'codec': stream.codec_context.name if stream.codec_context else 'unknown',
+                    'width': stream.width,
+                    'height': stream.height
+                })
+        
+        container.close()
+        return info
+        
+    except Exception:
+        return None
+
+
+def cleanup_temp_ogg(file_path: str) -> bool:
+    """
+    清理临时 OGG 文件
+    
+    Args:
+        file_path: 文件路径
+        
+    Returns:
+        bool: 是否成功删除
+    """
+    try:
+        if file_path and os.path.exists(file_path):
+            # 只删除临时目录中的文件
+            temp_dir = tempfile.gettempdir()
+            if file_path.startswith(temp_dir) and file_path.endswith('.ogg'):
+                os.remove(file_path)
+                return True
+        return False
+    except Exception:
+        return False
+
+
+def calculate_rms(audio_frame) -> float:
+    """
+    计算音频帧的 RMS（均方根）振幅
+    
+    Args:
+        audio_frame: PyAV 音频帧
+        
+    Returns:
+        float: RMS 值（线性振幅）
+    """
+    try:
+        import numpy as np
+        # 将音频帧转换为 numpy 数组
+        audio_array = audio_frame.to_ndarray()
+        # 计算 RMS
+        rms = np.sqrt(np.mean(audio_array ** 2))
+        return float(rms)
+    except Exception:
+        return 0.0
+
+
+def rms_to_db(rms: float) -> float:
+    """
+    将 RMS 值转换为分贝 (dB)
+    
+    Args:
+        rms: RMS 值（线性振幅）
+        
+    Returns:
+        float: 分贝值
+    """
+    if rms <= 0:
+        return -100.0  # 极小值
+    return 20 * math.log10(rms)
+
+
+def find_silence_near_target(
+    audio_path: str,
+    target_seconds: float = 1680.0,
+    search_window: float = 120.0,
+    silence_thresh_db: float = -40.0,
+    min_silence_duration: float = 0.5
+) -> float:
+    """
+    在目标时间点附近查找静音段
+    
+    Args:
+        audio_path: 音频文件路径
+        target_seconds: 目标时间点（秒）
+        search_window: 搜索窗口大小（秒），在 target_seconds 前后搜索
+        silence_thresh_db: 静音阈值（分贝），低于此值视为静音
+        min_silence_duration: 最小静音持续时间（秒）
+        
+    Returns:
+        float: 找到的静音点时间（秒），如果未找到则返回 target_seconds
+    """
+    try:
+        import av
+        import numpy as np
+    except ImportError:
+        return target_seconds
+    
+    try:
+        container = av.open(audio_path)
+        audio_streams = [s for s in container.streams if s.type == 'audio']
+        if not audio_streams:
+            container.close()
+            return target_seconds
+        
+        audio_stream = audio_streams[0]
+        sample_rate = audio_stream.sample_rate or 16000
+        
+        # 计算搜索范围
+        search_start = max(0, target_seconds - search_window)
+        search_end = target_seconds
+        
+        # 定位到搜索起始位置
+        seek_timestamp = int(search_start / audio_stream.time_base)
+        container.seek(seek_timestamp, stream=audio_stream)
+        
+        # 收集静音段
+        silence_segments = []
+        current_silence_start = None
+        
+        for packet in container.demux(audio_stream):
+            for frame in packet.decode():
+                if frame.pts is None:
+                    continue
+                
+                frame_time = float(frame.pts * audio_stream.time_base)
+                
+                # 超出搜索范围则停止
+                if frame_time > search_end:
+                    break
+                
+                # 计算 RMS 和 dB
+                rms = calculate_rms(frame)
+                db = rms_to_db(rms)
+                
+                # 检测静音
+                if db < silence_thresh_db:
+                    if current_silence_start is None:
+                        current_silence_start = frame_time
+                else:
+                    if current_silence_start is not None:
+                        silence_duration = frame_time - current_silence_start
+                        if silence_duration >= min_silence_duration:
+                            silence_segments.append((current_silence_start, frame_time))
+                        current_silence_start = None
+        
+        # 处理最后一个静音段
+        if current_silence_start is not None:
+            silence_duration = search_end - current_silence_start
+            if silence_duration >= min_silence_duration:
+                silence_segments.append((current_silence_start, search_end))
+        
+        container.close()
+        
+        # 选择最接近目标时间的静音段中点
+        if silence_segments:
+            best_silence = min(silence_segments, 
+                             key=lambda s: abs((s[0] + s[1]) / 2 - target_seconds))
+            split_point = (best_silence[0] + best_silence[1]) / 2
+            return split_point
+        
+        return target_seconds
+        
+    except Exception as e:
+        print(f"[静音检测] 错误: {e}")
+        return target_seconds
+
+
+def split_audio_by_duration(
+    input_path: str,
+    max_duration: float = 1680.0,
+    output_dir: Optional[str] = None,
+    sample_rate: int = OGG_SAMPLE_RATE,
+    channels: int = OGG_CHANNELS,
+    quality: int = OGG_QUALITY,
+    progress_callback: Optional[callable] = None
+) -> Tuple[bool, str, Optional[List[Tuple[str, float, float]]]]:
+    """
+    将音频文件分割成多个时长受限的片段（带静音检测）
+    
+    Args:
+        input_path: 输入音频文件路径
+        max_duration: 每个片段的最大时长（秒），默认 1680 秒（28 分钟）
+        output_dir: 输出目录，如果为 None 则使用临时目录
+        sample_rate: 采样率，默认 16000 Hz
+        channels: 声道数，默认 1（单声道）
+        quality: VBR 质量等级 0-10，默认 4
+        progress_callback: 进度回调函数，接收 (current_chunk, total_chunks, message) 参数
+        
+    Returns:
+        Tuple[bool, str, Optional[List[Tuple[str, float, float]]]]: 
+        (成功与否, 消息, 片段信息列表 [(文件路径, 起始时间, 结束时间)])
+    """
+    import datetime
+    
+    def log_with_time(msg):
+        timestamp = datetime.datetime.now().strftime("%H:%M:%S")
+        print(f"[{timestamp}] [音频分割] {msg}")
+    
+    try:
+        import av
+    except ImportError:
+        return False, "PyAV 库未安装，请运行: pip install av", None
+    
+    if not os.path.exists(input_path):
+        return False, f"输入文件不存在: {input_path}", None
+    
+    # 获取音频总时长
+    media_info = get_media_info(input_path)
+    if not media_info or media_info['duration'] <= 0:
+        return False, "无法获取音频时长", None
+    
+    total_duration = media_info['duration']
+    
+    # 如果时长小于最大时长，无需分割
+    if total_duration <= max_duration:
+        return False, f"音频时长 {total_duration:.1f}s 小于最大时长 {max_duration:.1f}s，无需分割", None
+    
+    # 设置输出目录
+    if output_dir is None:
+        output_dir = tempfile.gettempdir()
+    
+    # 计算分割点
+    split_points = [0.0]
+    current_pos = 0.0
+    
+    while current_pos + max_duration < total_duration:
+        target_split = current_pos + max_duration
+        # 使用静音检测查找最佳分割点
+        actual_split = find_silence_near_target(
+            input_path, 
+            target_seconds=target_split,
+            search_window=120.0,
+            silence_thresh_db=-40.0,
+            min_silence_duration=0.5
+        )
+        split_points.append(actual_split)
+        current_pos = actual_split
+    
+    split_points.append(total_duration)
+    
+    # 生成输出文件列表
+    base_name = Path(input_path).stem
+    chunk_info = []
+    
+    num_chunks = len(split_points) - 1
+    log_with_time(f"将分割为 {num_chunks} 个片段")
+    
+    # 提取每个片段
+    for i in range(num_chunks):
+        start_time = split_points[i]
+        end_time = split_points[i + 1]
+        chunk_duration = end_time - start_time
+        
+        output_path = os.path.join(output_dir, f"{base_name}_part{i+1:03d}.ogg")
+        
+        if progress_callback:
+            progress_callback(i + 1, num_chunks, f"正在分割片段 {i+1}/{num_chunks} ({chunk_duration:.1f}s)")
+        
+        log_with_time(f"片段 {i+1}/{num_chunks}: {start_time:.1f}s - {end_time:.1f}s -> {output_path}")
+        
+        # 提取片段
+        success = extract_audio_segment(
+            input_path, output_path,
+            start_time, end_time,
+            sample_rate, channels, quality
+        )
+        
+        if not success:
+            return False, f"提取片段 {i+1} 失败", None
+        
+        chunk_info.append((output_path, start_time, end_time))
+    
+    return True, f"成功分割为 {num_chunks} 个片段", chunk_info
+
+
+def extract_audio_segment(
+    input_path: str,
+    output_path: str,
+    start_time: float,
+    end_time: float,
+    sample_rate: int = OGG_SAMPLE_RATE,
+    channels: int = OGG_CHANNELS,
+    quality: int = OGG_QUALITY
+) -> bool:
+    """
+    从音频文件中提取指定时间段
+    
+    Args:
+        input_path: 输入音频文件路径
+        output_path: 输出文件路径
+        start_time: 起始时间（秒）
+        end_time: 结束时间（秒）
+        sample_rate: 采样率
+        channels: 声道数
+        quality: VBR 质量等级
+        
+    Returns:
+        bool: 是否成功
+    """
+    try:
+        import av
+    except ImportError:
+        return False
+    
+    try:
+        input_container = av.open(input_path)
+        audio_streams = [s for s in input_container.streams if s.type == 'audio']
+        if not audio_streams:
+            input_container.close()
+            return False
+        
+        input_audio_stream = audio_streams[0]
+        
+        # 定位到起始位置
+        seek_timestamp = int(start_time / input_audio_stream.time_base)
+        input_container.seek(seek_timestamp, stream=input_audio_stream)
+        
+        # 创建输出容器
+        output_container = av.open(output_path, 'w')
+        output_audio_stream = output_container.add_stream('libvorbis', rate=sample_rate)
+        output_audio_stream.codec_context.layout = 'mono' if channels == 1 else 'stereo'
+        
+        # 创建重采样器
+        resampler = av.AudioResampler(
+            format='fltp',
+            layout='mono' if channels == 1 else 'stereo',
+            rate=sample_rate
+        )
+        
+        # 处理音频帧
+        for packet in input_container.demux(input_audio_stream):
+            for frame in packet.decode():
+                if frame.pts is None:
+                    continue
+                
+                frame_time = float(frame.pts * input_audio_stream.time_base)
+                
+                # 超出结束时间则停止
+                if frame_time >= end_time:
+                    break
+                
+                # 跳过起始时间之前的帧
+                if frame_time < start_time:
+                    continue
+                
+                # 重采样并编码
+                resampled_frames = resampler.resample(frame)
+                for resampled_frame in resampled_frames:
+                    for out_packet in output_audio_stream.encode(resampled_frame):
+                        output_container.mux(out_packet)
+        
+        # 刷新编码器
+        for out_packet in output_audio_stream.encode(None):
+            output_container.mux(out_packet)
+        
+        output_container.close()
+        input_container.close()
+        
+        return os.path.exists(output_path) and os.path.getsize(output_path) > 0
+        
+    except Exception as e:
+        print(f"[音频分割] 提取片段失败: {e}")
+        return False
+
+
+def merge_elevenlabs_transcriptions(
+    json_files: List[str],
+    chunk_info: List[Tuple[str, float, float]],
+    output_path: str
+) -> Tuple[bool, str]:
+    """
+    合并多个 ElevenLabs 转录 JSON 文件
+    
+    Args:
+        json_files: JSON 文件路径列表
+        chunk_info: 片段信息列表 [(文件路径, 起始时间, 结束时间)]
+        output_path: 输出合并后的 JSON 文件路径
+        
+    Returns:
+        Tuple[bool, str]: (成功与否, 消息)
+    """
+    try:
+        if len(json_files) != len(chunk_info):
+            return False, "JSON 文件数量与片段信息不匹配"
+        
+        merged = {
+            "text": "",
+            "words": [],
+            "language_code": None,
+            "language_confidence": 0.0
+        }
+        
+        for i, (json_file, chunk_tuple) in enumerate(zip(json_files, chunk_info)):
+            if not os.path.exists(json_file):
+                return False, f"JSON 文件不存在: {json_file}"
+            
+            chunk_start_offset = chunk_tuple[1]  # 起始时间
+            
+            with open(json_file, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+            
+            # 合并文本（添加空格分隔）
+            if i > 0 and merged["text"] and data.get("text"):
+                merged["text"] += " "
+            merged["text"] += data.get("text", "")
+            
+            # 调整时间戳并合并单词
+            for word in data.get("words", []):
+                adjusted_word = word.copy()
+                if "start" in adjusted_word:
+                    adjusted_word["start"] += chunk_start_offset
+                if "end" in adjusted_word:
+                    adjusted_word["end"] += chunk_start_offset
+                merged["words"].append(adjusted_word)
+            
+            # 使用第一个片段的语言信息
+            if i == 0:
+                merged["language_code"] = data.get("language_code")
+                merged["language_confidence"] = data.get("language_confidence", 0.0)
+        
+        # 写入合并后的 JSON
+        with open(output_path, 'w', encoding='utf-8') as f:
+            json.dump(merged, f, ensure_ascii=False, indent=2)
+        
+        total_words = len(merged["words"])
+        return True, f"成功合并 {len(json_files)} 个文件，共 {total_words} 个单词"
+        
+    except Exception as e:
+        return False, f"合并 JSON 失败: {str(e)}"

--- a/tools/core/audio_processor.py
+++ b/tools/core/audio_processor.py
@@ -1,0 +1,219 @@
+"""
+音频处理编排模块 - 纯 Python 实现，无 GUI 依赖
+
+提供批量音频处理的高级编排功能，适用于：
+- 命令行工具
+- Web 服务
+- 批处理脚本
+
+作者: fuxiaomoke
+版本: 0.2.2.0
+"""
+
+from typing import List, Tuple, Dict, Optional, Callable
+import os
+from tools.core.audio_extractor import (
+    extract_audio_to_ogg, split_audio_by_duration,
+    get_media_info, is_video_file, is_audio_file
+)
+
+
+class AudioProcessor:
+    """
+    音频处理编排器（纯 Python，无 Qt 依赖）
+    
+    使用回调函数模式传递进度和状态，适配任何 UI 框架或 CLI
+    """
+    
+    def __init__(self, 
+                 progress_callback: Optional[Callable[[str], None]] = None,
+                 error_callback: Optional[Callable[[str], None]] = None):
+        """
+        Args:
+            progress_callback: 进度回调 (message: str)
+            error_callback: 错误回调 (error_message: str)
+        """
+        self.progress_callback = progress_callback
+        self.error_callback = error_callback
+        self.extracted_files: Dict[str, str] = {}
+        self.split_results: Dict[str, List] = {}
+    
+    def _log(self, message: str):
+        """内部日志"""
+        if self.progress_callback:
+            self.progress_callback(message)
+        else:
+            print(message)
+    
+    def _error(self, message: str):
+        """内部错误"""
+        if self.error_callback:
+            self.error_callback(message)
+        else:
+            print(f"ERROR: {message}")
+    
+    def extract_multiple_videos(
+        self, 
+        video_files: List[str]
+    ) -> Dict[str, str]:
+        """
+        批量提取视频音频
+        
+        Args:
+            video_files: 视频文件路径列表
+        
+        Returns:
+            Dict[原始视频路径, 提取的音频路径]
+        
+        Raises:
+            Exception: 提取失败时抛出
+        """
+        results = {}
+        total = len(video_files)
+        
+        for i, video_path in enumerate(video_files, 1):
+            self._log(f"[{i}/{total}] 提取音频: {os.path.basename(video_path)}")
+            
+            def progress_cb(current, total_duration):
+                if total_duration > 0:
+                    percent = (current / total_duration) * 100
+                    self._log(f"[{i}/{total}] 提取进度: {percent:.1f}%")
+            
+            success, msg, audio_path = extract_audio_to_ogg(
+                video_path,
+                progress_callback=progress_cb
+            )
+            
+            if success:
+                results[video_path] = audio_path
+                self._log(f"[{i}/{total}] 完成: {audio_path}")
+            else:
+                error_msg = f"提取失败 [{os.path.basename(video_path)}]: {msg}"
+                self._error(error_msg)
+                raise Exception(error_msg)
+        
+        return results
+    
+    def split_long_audios(
+        self,
+        audio_files: List[str],
+        max_duration: float = 1800.0,
+        split_duration: float = 1680.0
+    ) -> Dict[str, List[Tuple[str, float, float]]]:
+        """
+        检查并分割超长音频
+        
+        Args:
+            audio_files: 音频文件路径列表
+            max_duration: 触发分割的最大时长（秒）
+            split_duration: 分割后每段的最大时长（秒）
+        
+        Returns:
+            Dict[原始音频路径, chunk_info列表]
+            chunk_info = [(chunk_path, start_time, end_time), ...]
+        """
+        results = {}
+        files_need_split = []
+        
+        # 检查哪些文件需要分割
+        for audio_file in audio_files:
+            info = get_media_info(audio_file)
+            if not info:
+                self._error(f"无法获取音频信息: {audio_file}")
+                continue
+            
+            if info['duration'] > max_duration:
+                files_need_split.append((audio_file, info['duration']))
+            else:
+                # 不需要分割
+                results[audio_file] = [(audio_file, 0.0, info['duration'])]
+        
+        if not files_need_split:
+            return results
+        
+        # 分割超长音频
+        total = len(files_need_split)
+        for i, (audio_file, duration) in enumerate(files_need_split, 1):
+            self._log(f"[{i}/{total}] 分割音频: {os.path.basename(audio_file)} ({duration/60:.1f}分钟)")
+            
+            def progress_cb(curr_chunk, total_chunks, msg):
+                self._log(f"[{i}/{total}] {msg}")
+            
+            success, msg, chunk_info = split_audio_by_duration(
+                audio_file,
+                max_duration=split_duration,
+                progress_callback=progress_cb
+            )
+            
+            if success and chunk_info:
+                results[audio_file] = chunk_info
+                self._log(f"[{i}/{total}] 完成: 分割为 {len(chunk_info)} 个片段")
+            else:
+                error_msg = f"分割失败 [{os.path.basename(audio_file)}]: {msg}"
+                self._error(error_msg)
+                raise Exception(error_msg)
+        
+        return results
+    
+    def process_media_batch(
+        self,
+        media_files: List[str],
+        auto_split: bool = True,
+        max_duration: float = 1800.0,
+        split_duration: float = 1680.0
+    ) -> Tuple[List[str], Dict[str, List[Tuple[str, float, float]]]]:
+        """
+        批量处理媒体文件（视频提取 + 音频分割）
+        
+        Args:
+            media_files: 媒体文件路径列表（视频或音频）
+            auto_split: 是否自动分割超长音频
+            max_duration: 触发分割的最大时长
+            split_duration: 分割后每段的最大时长
+        
+        Returns:
+            (audio_files, split_info)
+            - audio_files: 处理后的音频文件列表
+            - split_info: 分割信息字典
+        """
+        # 1. 分离视频和音频
+        video_files = [f for f in media_files if is_video_file(f)]
+        audio_files = [f for f in media_files if is_audio_file(f)]
+        
+        # 2. 提取视频音频
+        if video_files:
+            self._log(f"检测到 {len(video_files)} 个视频文件，开始提取音频...")
+            extracted = self.extract_multiple_videos(video_files)
+            audio_files.extend(extracted.values())
+            self.extracted_files = extracted
+        
+        # 3. 分割超长音频
+        split_info = {}
+        if auto_split and audio_files:
+            self._log(f"检查 {len(audio_files)} 个音频文件是否需要分割...")
+            split_info = self.split_long_audios(audio_files, max_duration, split_duration)
+            self.split_results = split_info
+        
+        return audio_files, split_info
+
+
+# ============ 便捷函数（供快速调用）============
+
+def extract_videos(
+    video_files: List[str],
+    progress_callback: Optional[Callable] = None
+) -> Dict[str, str]:
+    """便捷函数：批量提取视频音频"""
+    processor = AudioProcessor(progress_callback=progress_callback)
+    return processor.extract_multiple_videos(video_files)
+
+
+def split_long_audios(
+    audio_files: List[str],
+    max_duration: float = 1800.0,
+    split_duration: float = 1680.0,
+    progress_callback: Optional[Callable] = None
+) -> Dict[str, List[Tuple[str, float, float]]]:
+    """便捷函数：检查并分割超长音频"""
+    processor = AudioProcessor(progress_callback=progress_callback)
+    return processor.split_long_audios(audio_files, max_duration, split_duration)

--- a/tools/core/subtitle_pipeline.py
+++ b/tools/core/subtitle_pipeline.py
@@ -1,0 +1,340 @@
+"""
+字幕生成流程编排模块
+
+独立的命令行工具核心逻辑，不依赖 GUI 组件。
+实现完整的视频转字幕流程：音频提取 → 分割 → 转录 → 合并 → LLM优化 → SRT生成
+
+作者: fuxiaomoke
+版本: 0.2.2.0
+"""
+
+import os
+import sys
+import json
+import tempfile
+from pathlib import Path
+from typing import List, Tuple, Optional, Dict, Any
+from datetime import datetime
+
+# 添加项目根目录和 src 目录到 Python 路径
+project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+src_path = os.path.join(project_root, 'src')
+if src_path not in sys.path:
+    sys.path.insert(0, src_path)
+
+# 从 src 导入可复用的模块
+from core.elevenlabs_api import ElevenLabsSTTClient
+from core.transcription_parser import TranscriptionParser
+from core.srt_processor import SrtProcessor
+from core.llm_api import call_llm_api_for_segmentation
+
+# 从 tools.core 导入音频处理模块
+from tools.core.audio_extractor import (
+    extract_audio_to_ogg, split_audio_by_duration, 
+    get_media_info, is_video_file, is_audio_file,
+    merge_elevenlabs_transcriptions
+)
+
+
+class SubtitlePipeline:
+    """无 GUI 依赖的字幕生成流程编排器"""
+    
+    def __init__(self, config: Dict[str, Any]):
+        """
+        初始化流程编排器
+        
+        Args:
+            config: 配置字典，包含：
+                - llm_api_key: LLM API密钥
+                - llm_api_url: LLM API地址
+                - llm_model: LLM模型名称
+                - language: 目标语言 (zh/ja/en/ko)
+                - max_chunk_duration: 最大分割时长（秒）
+                - temperature: LLM温度参数
+        """
+        self.config = config
+        self.temp_files = []  # 记录临时文件用于清理
+        
+    def _log(self, message: str):
+        """输出带时间戳的日志"""
+        timestamp = datetime.now().strftime("%H:%M:%S")
+        print(f"[{timestamp}] {message}")
+    
+    def process_video(self, video_path: str) -> str:
+        """
+        完整流程：视频 → SRT
+        
+        Args:
+            video_path: 视频文件路径
+            
+        Returns:
+            str: 生成的SRT文件路径
+        """
+        try:
+            self._log(f"开始处理视频: {video_path}")
+            
+            # Step 1: 提取音频
+            self._log("=" * 60)
+            self._log("步骤 1/5: 提取音频")
+            audio_path = self._extract_audio(video_path)
+            self._log(f"OK: 音频提取完成: {audio_path}")
+            
+            # Step 2: 分割音频（如果需要）
+            self._log("=" * 60)
+            self._log("步骤 2/5: 检查音频时长并分割")
+            chunks = self._split_audio_if_needed(audio_path)
+            if len(chunks) > 1:
+                self._log(f"OK: 音频已分割为 {len(chunks)} 个片段")
+            else:
+                self._log("OK: 音频无需分割")
+            
+            # Step 3: 批量转录
+            self._log("=" * 60)
+            self._log("步骤 3/5: ElevenLabs 转录")
+            json_files = self._transcribe_chunks(chunks)
+            self._log(f"OK: 转录完成，生成 {len(json_files)} 个JSON文件")
+            
+            # Step 4: 合并 JSON（如果有多个）
+            self._log("=" * 60)
+            self._log("步骤 4/5: 合并转录结果")
+            if len(json_files) > 1:
+                merged_json = self._merge_transcriptions(json_files, chunks)
+                self._log(f"OK: JSON合并完成: {merged_json}")
+            else:
+                merged_json = json_files[0]
+                self._log(f"OK: 单文件无需合并: {merged_json}")
+            
+            # Step 5: LLM 优化 + SRT 生成
+            self._log("=" * 60)
+            self._log("步骤 5/5: LLM优化并生成SRT")
+            srt_path = self._generate_srt(merged_json, video_path)
+            self._log(f"OK: SRT生成完成: {srt_path}")
+            
+            self._log("=" * 60)
+            self._log("OK: 全部完成！")
+            
+            return srt_path
+            
+        except Exception as e:
+            self._log(f"Error: 处理失败: {e}")
+            import traceback
+            traceback.print_exc()
+            raise
+        finally:
+            # 清理临时文件
+            self._cleanup_temp_files()
+    
+    def _extract_audio(self, video_path: str) -> str:
+        """提取音频并转换为OGG格式"""
+        # 检查文件类型
+        if is_audio_file(video_path):
+            self._log("输入文件是音频格式，直接使用")
+            return video_path
+        
+        if not is_video_file(video_path):
+            raise ValueError(f"不支持的文件格式: {video_path}")
+        
+        # 提取音频
+        last_percent = [-1]  # 使用列表避免闭包问题
+        def progress_callback(current, total):
+            if total > 0:
+                percent = round((current / total) * 100, 1)
+                if percent != last_percent[0]:
+                    print(f"\r  提取进度: {percent:.1f}%", end='', flush=True)
+                    last_percent[0] = percent
+        
+        print("  提取音频中...", end='', flush=True)
+        
+        success, msg, audio_path = extract_audio_to_ogg(
+            video_path,
+            progress_callback=progress_callback
+        )
+        
+        if not success:
+            print()  # 换行
+            raise Exception(f"音频提取失败: {msg}")
+        
+        print()  # 完成后换行
+        self.temp_files.append(audio_path)
+        return audio_path
+    
+    def _split_audio_if_needed(self, audio_path: str) -> List[Tuple[str, float, float]]:
+        """如果音频超过最大时长则分割"""
+        # 获取音频信息
+        info = get_media_info(audio_path)
+        if not info:
+            raise Exception("无法获取音频信息")
+        
+        duration = info['duration']
+        max_duration = self.config.get('max_chunk_duration', 1680)
+        
+        self._log(f"  音频时长: {duration:.1f}秒 ({duration/60:.1f}分钟)")
+        self._log(f"  最大时长限制: {max_duration}秒 ({max_duration/60:.1f}分钟)")
+        
+        # 如果不需要分割
+        if duration <= max_duration:
+            return [(audio_path, 0.0, duration)]
+        
+        # 分割音频
+        self._log(f"  音频超过限制，开始分割...")
+        
+        def progress_callback(current, total, message):
+            self._log(f"  {message}")
+        
+        success, msg, chunks = split_audio_by_duration(
+            audio_path,
+            max_duration=max_duration,
+            progress_callback=progress_callback
+        )
+        
+        if not success:
+            raise Exception(f"音频分割失败: {msg}")
+        
+        # 记录临时文件
+        for chunk_path, _, _ in chunks:
+            self.temp_files.append(chunk_path)
+        
+        return chunks
+    
+    def _transcribe_chunks(self, chunks: List[Tuple[str, float, float]]) -> List[str]:
+        """使用 ElevenLabs 转录所有音频片段"""
+        client = ElevenLabsSTTClient()
+        json_files = []
+        
+        # 获取 ElevenLabs API Key（如果有）
+        elevenlabs_api_key = self.config.get('elevenlabs_api_key', '')
+        
+        for i, (chunk_path, start, end) in enumerate(chunks, 1):
+            duration = end - start
+            self._log(f"  [{i}/{len(chunks)}] 转录: {os.path.basename(chunk_path)} ({duration:.1f}秒)")
+            
+            # 根据是否有 API Key 选择不同的转录方法
+            if elevenlabs_api_key:
+                self._log(f"  使用 ElevenLabs API (付费版)")
+                result = client.transcribe_audio_official_api(
+                    audio_file_path=chunk_path,
+                    api_key=elevenlabs_api_key,
+                    language_code=self.config.get('language'),
+                    num_speakers=0,
+                    enable_diarization=True,
+                    tag_audio_events=True
+                )
+            else:
+                self._log(f"  使用 ElevenLabs Web (免费版，可能失效)")
+                result = client.transcribe_audio(
+                    chunk_path,
+                    language_code=self.config.get('language'),
+                    tag_audio_events=True
+                )
+            
+            if not result:
+                raise Exception(f"转录失败: {chunk_path}")
+            
+            # 保存 JSON
+            json_path = chunk_path.rsplit('.', 1)[0] + '.json'
+            with open(json_path, 'w', encoding='utf-8') as f:
+                json.dump(result, f, ensure_ascii=False, indent=2)
+            
+            self._log(f"  OK: 已保存: {json_path}")
+            json_files.append(json_path)
+            self.temp_files.append(json_path)
+        
+        return json_files
+    
+    def _merge_transcriptions(self, json_files: List[str], chunks: List[Tuple]) -> str:
+        """合并多个转录JSON文件"""
+        # 生成合并文件路径
+        base_path = json_files[0].replace('_part001.json', '_merged.json')
+        if base_path == json_files[0]:
+            # 如果没有 _part001 后缀，使用其他命名
+            base_path = json_files[0].rsplit('.', 1)[0] + '_merged.json'
+        
+        self._log(f"  合并 {len(json_files)} 个JSON文件...")
+        
+        success, msg = merge_elevenlabs_transcriptions(json_files, chunks, base_path)
+        
+        if not success:
+            raise Exception(f"合并失败: {msg}")
+        
+        self._log(f"  OK: {msg}")
+        self.temp_files.append(base_path)
+        return base_path
+    
+    def _generate_srt(self, json_path: str, video_path: str) -> str:
+        """LLM优化并生成SRT"""
+        # 1. 解析 JSON
+        self._log("  解析转录JSON...")
+        with open(json_path, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+        
+        parser = TranscriptionParser()
+        parsed = parser.parse(data, 'elevenlabs')
+        
+        if not parsed:
+            raise Exception("JSON解析失败")
+        
+        self._log(f"  OK: 解析完成: {len(parsed.words)} 个单词")
+        
+        # 2. 提取文本
+        full_text = ' '.join([w.text for w in parsed.words])
+        self._log(f"  文本长度: {len(full_text)} 字符")
+        
+        # 3. LLM 分割优化
+        self._log("  调用LLM进行文本分割优化...")
+        segments = call_llm_api_for_segmentation(
+            api_key=self.config['llm_api_key'],
+            text_to_segment=full_text,
+            custom_api_base_url_str=self.config.get('llm_api_url'),
+            custom_model_name=self.config.get('llm_model'),
+            custom_temperature=self.config.get('temperature', 0.3),
+            target_language=self.config.get('language')
+        )
+        
+        if not segments:
+            raise Exception("LLM分割失败")
+        
+        self._log(f"  OK: LLM分割完成: {len(segments)} 个片段")
+        
+        # 4. 生成 SRT
+        self._log("  生成SRT字幕...")
+        processor = SrtProcessor()
+        
+        srt_content, _ = processor.process_to_srt(
+            parsed_transcription=parsed,
+            llm_segments_text=segments,
+            source_format='elevenlabs',
+            enable_ai_correction=False
+        )
+        
+        # 5. 保存 SRT
+        srt_path = video_path.rsplit('.', 1)[0] + '.srt'
+        with open(srt_path, 'w', encoding='utf-8') as f:
+            f.write(srt_content)
+        
+        # 统计字幕条目数
+        subtitle_count = srt_content.count('\n\n') + 1
+        self._log(f"  OK: 生成 {subtitle_count} 条字幕")
+        
+        return srt_path
+    
+    def _cleanup_temp_files(self):
+        """清理临时文件"""
+        # 暂时禁用清理，方便调试
+        return
+        
+        if not self.temp_files:
+            return
+        
+        self._log("清理临时文件...")
+        temp_dir = tempfile.gettempdir()
+        
+        for file_path in self.temp_files:
+            try:
+                # 只删除临时目录中的文件
+                if file_path.startswith(temp_dir) and os.path.exists(file_path):
+                    os.remove(file_path)
+                    self._log(f"  OK: 已删除: {os.path.basename(file_path)}")
+            except Exception as e:
+                self._log(f"  Error: 删除失败 {os.path.basename(file_path)}: {e}")

--- a/tools/core/subtitle_pipeline.py
+++ b/tools/core/subtitle_pipeline.py
@@ -32,7 +32,7 @@ from core.llm_api import call_llm_api_for_segmentation
 
 # 从 tools.core 导入音频处理模块
 from tools.core.audio_extractor import (
-    extract_audio_to_ogg, split_audio_by_duration, 
+    extract_audio_to_ogg, split_audio_by_duration,
     get_media_info, is_video_file, is_audio_file,
     merge_elevenlabs_transcriptions
 )
@@ -40,11 +40,11 @@ from tools.core.audio_extractor import (
 
 class SubtitlePipeline:
     """无 GUI 依赖的字幕生成流程编排器"""
-    
+
     def __init__(self, config: Dict[str, Any]):
         """
         初始化流程编排器
-        
+
         Args:
             config: 配置字典，包含：
                 - llm_api_key: LLM API密钥
@@ -56,31 +56,31 @@ class SubtitlePipeline:
         """
         self.config = config
         self.temp_files = []  # 记录临时文件用于清理
-        
+
     def _log(self, message: str):
         """输出带时间戳的日志"""
         timestamp = datetime.now().strftime("%H:%M:%S")
         print(f"[{timestamp}] {message}")
-    
+
     def process_video(self, video_path: str) -> str:
         """
         完整流程：视频 → SRT
-        
+
         Args:
             video_path: 视频文件路径
-            
+
         Returns:
             str: 生成的SRT文件路径
         """
         try:
             self._log(f"开始处理视频: {video_path}")
-            
+
             # Step 1: 提取音频
             self._log("=" * 60)
             self._log("步骤 1/5: 提取音频")
             audio_path = self._extract_audio(video_path)
             self._log(f"OK: 音频提取完成: {audio_path}")
-            
+
             # Step 2: 分割音频（如果需要）
             self._log("=" * 60)
             self._log("步骤 2/5: 检查音频时长并分割")
@@ -89,13 +89,13 @@ class SubtitlePipeline:
                 self._log(f"OK: 音频已分割为 {len(chunks)} 个片段")
             else:
                 self._log("OK: 音频无需分割")
-            
+
             # Step 3: 批量转录
             self._log("=" * 60)
             self._log("步骤 3/5: ElevenLabs 转录")
             json_files = self._transcribe_chunks(chunks)
             self._log(f"OK: 转录完成，生成 {len(json_files)} 个JSON文件")
-            
+
             # Step 4: 合并 JSON（如果有多个）
             self._log("=" * 60)
             self._log("步骤 4/5: 合并转录结果")
@@ -105,18 +105,18 @@ class SubtitlePipeline:
             else:
                 merged_json = json_files[0]
                 self._log(f"OK: 单文件无需合并: {merged_json}")
-            
+
             # Step 5: LLM 优化 + SRT 生成
             self._log("=" * 60)
             self._log("步骤 5/5: LLM优化并生成SRT")
             srt_path = self._generate_srt(merged_json, video_path)
             self._log(f"OK: SRT生成完成: {srt_path}")
-            
+
             self._log("=" * 60)
             self._log("OK: 全部完成！")
-            
+
             return srt_path
-            
+
         except Exception as e:
             self._log(f"Error: 处理失败: {e}")
             import traceback
@@ -125,17 +125,17 @@ class SubtitlePipeline:
         finally:
             # 清理临时文件
             self._cleanup_temp_files()
-    
+
     def _extract_audio(self, video_path: str) -> str:
         """提取音频并转换为OGG格式"""
         # 检查文件类型
         if is_audio_file(video_path):
             self._log("输入文件是音频格式，直接使用")
             return video_path
-        
+
         if not is_video_file(video_path):
             raise ValueError(f"不支持的文件格式: {video_path}")
-        
+
         # 提取音频
         last_percent = [-1]  # 使用列表避免闭包问题
         def progress_callback(current, total):
@@ -144,72 +144,72 @@ class SubtitlePipeline:
                 if percent != last_percent[0]:
                     print(f"\r  提取进度: {percent:.1f}%", end='', flush=True)
                     last_percent[0] = percent
-        
+
         print("  提取音频中...", end='', flush=True)
-        
+
         success, msg, audio_path = extract_audio_to_ogg(
             video_path,
             progress_callback=progress_callback
         )
-        
+
         if not success:
             print()  # 换行
             raise Exception(f"音频提取失败: {msg}")
-        
+
         print()  # 完成后换行
         self.temp_files.append(audio_path)
         return audio_path
-    
+
     def _split_audio_if_needed(self, audio_path: str) -> List[Tuple[str, float, float]]:
         """如果音频超过最大时长则分割"""
         # 获取音频信息
         info = get_media_info(audio_path)
         if not info:
             raise Exception("无法获取音频信息")
-        
+
         duration = info['duration']
         max_duration = self.config.get('max_chunk_duration', 1680)
-        
+
         self._log(f"  音频时长: {duration:.1f}秒 ({duration/60:.1f}分钟)")
         self._log(f"  最大时长限制: {max_duration}秒 ({max_duration/60:.1f}分钟)")
-        
+
         # 如果不需要分割
         if duration <= max_duration:
             return [(audio_path, 0.0, duration)]
-        
+
         # 分割音频
         self._log(f"  音频超过限制，开始分割...")
-        
+
         def progress_callback(current, total, message):
             self._log(f"  {message}")
-        
+
         success, msg, chunks = split_audio_by_duration(
             audio_path,
             max_duration=max_duration,
             progress_callback=progress_callback
         )
-        
+
         if not success:
             raise Exception(f"音频分割失败: {msg}")
-        
+
         # 记录临时文件
         for chunk_path, _, _ in chunks:
             self.temp_files.append(chunk_path)
-        
+
         return chunks
-    
+
     def _transcribe_chunks(self, chunks: List[Tuple[str, float, float]]) -> List[str]:
         """使用 ElevenLabs 转录所有音频片段"""
         client = ElevenLabsSTTClient()
         json_files = []
-        
+
         # 获取 ElevenLabs API Key（如果有）
         elevenlabs_api_key = self.config.get('elevenlabs_api_key', '')
-        
+
         for i, (chunk_path, start, end) in enumerate(chunks, 1):
             duration = end - start
             self._log(f"  [{i}/{len(chunks)}] 转录: {os.path.basename(chunk_path)} ({duration:.1f}秒)")
-            
+
             # 根据是否有 API Key 选择不同的转录方法
             if elevenlabs_api_key:
                 self._log(f"  使用 ElevenLabs API (付费版)")
@@ -228,21 +228,21 @@ class SubtitlePipeline:
                     language_code=self.config.get('language'),
                     tag_audio_events=True
                 )
-            
+
             if not result:
                 raise Exception(f"转录失败: {chunk_path}")
-            
+
             # 保存 JSON
             json_path = chunk_path.rsplit('.', 1)[0] + '.json'
             with open(json_path, 'w', encoding='utf-8') as f:
                 json.dump(result, f, ensure_ascii=False, indent=2)
-            
+
             self._log(f"  OK: 已保存: {json_path}")
             json_files.append(json_path)
             self.temp_files.append(json_path)
-        
+
         return json_files
-    
+
     def _merge_transcriptions(self, json_files: List[str], chunks: List[Tuple]) -> str:
         """合并多个转录JSON文件"""
         # 生成合并文件路径
@@ -250,37 +250,37 @@ class SubtitlePipeline:
         if base_path == json_files[0]:
             # 如果没有 _part001 后缀，使用其他命名
             base_path = json_files[0].rsplit('.', 1)[0] + '_merged.json'
-        
+
         self._log(f"  合并 {len(json_files)} 个JSON文件...")
-        
+
         success, msg = merge_elevenlabs_transcriptions(json_files, chunks, base_path)
-        
+
         if not success:
             raise Exception(f"合并失败: {msg}")
-        
+
         self._log(f"  OK: {msg}")
         self.temp_files.append(base_path)
         return base_path
-    
+
     def _generate_srt(self, json_path: str, video_path: str) -> str:
         """LLM优化并生成SRT"""
         # 1. 解析 JSON
         self._log("  解析转录JSON...")
         with open(json_path, 'r', encoding='utf-8') as f:
             data = json.load(f)
-        
+
         parser = TranscriptionParser()
         parsed = parser.parse(data, 'elevenlabs')
-        
+
         if not parsed:
             raise Exception("JSON解析失败")
-        
+
         self._log(f"  OK: 解析完成: {len(parsed.words)} 个单词")
-        
+
         # 2. 提取文本
         full_text = ' '.join([w.text for w in parsed.words])
         self._log(f"  文本长度: {len(full_text)} 字符")
-        
+
         # 3. LLM 分割优化
         self._log("  调用LLM进行文本分割优化...")
         segments = call_llm_api_for_segmentation(
@@ -291,45 +291,42 @@ class SubtitlePipeline:
             custom_temperature=self.config.get('temperature', 0.3),
             target_language=self.config.get('language')
         )
-        
+
         if not segments:
             raise Exception("LLM分割失败")
-        
+
         self._log(f"  OK: LLM分割完成: {len(segments)} 个片段")
-        
+
         # 4. 生成 SRT
         self._log("  生成SRT字幕...")
         processor = SrtProcessor()
-        
+
         srt_content, _ = processor.process_to_srt(
             parsed_transcription=parsed,
             llm_segments_text=segments,
             source_format='elevenlabs',
             enable_ai_correction=False
         )
-        
+
         # 5. 保存 SRT
         srt_path = video_path.rsplit('.', 1)[0] + '.srt'
         with open(srt_path, 'w', encoding='utf-8') as f:
             f.write(srt_content)
-        
+
         # 统计字幕条目数
         subtitle_count = srt_content.count('\n\n') + 1
         self._log(f"  OK: 生成 {subtitle_count} 条字幕")
-        
+
         return srt_path
-    
+
     def _cleanup_temp_files(self):
         """清理临时文件"""
-        # 暂时禁用清理，方便调试
-        return
-        
         if not self.temp_files:
             return
-        
+
         self._log("清理临时文件...")
         temp_dir = tempfile.gettempdir()
-        
+
         for file_path in self.temp_files:
             try:
                 # 只删除临时目录中的文件


### PR DESCRIPTION
tools/auto_subtitle.py

可以将其分割成28分钟的短音频（以避开远程eleven web的30分钟限制），尽量挑选静音时点切割，再调用远程api并将返回的多个json组合；如果用无限制的付费 api则不分割。

最后再模仿原来ui的功能调用LLM生成最后的srt文件。